### PR TITLE
Implement KV token storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ await fetch('/api/token', {
 });
 ```
 
-The token will be encrypted and stored securely using the worker's storage
-mechanism.
+The token will be encrypted and stored securely in the worker's `user-pat-store`
+KV namespace.

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,4 +1,11 @@
-/** Placeholder functions for GitHub OAuth and repository state sync */
+/**
+ * Utility stubs for interacting with the GitHub API.
+ *
+ * In the real worker these would exchange OAuth codes for tokens
+ * and push editor state to a repository. They remain mocked here
+ * so the rest of the application can compile without access to
+ * the GitHub API during development.
+ */
 
 export async function authenticateWithGitHub(code: string): Promise<string> {
   // TODO: exchange OAuth code for access token

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,3 +2,6 @@ name = "open-user-state-personal-website"
 main = "src/index.ts"
 compatibility_date = "2024-05-25"
 node_compat = true
+kv_namespaces = [
+  { binding = "USER_PAT_STORE", id = "8b99c8c064fc4eadb803d6018f4516b9", preview_id = "8b99c8c064fc4eadb803d6018f4516b9" }
+]


### PR DESCRIPTION
## Summary
- store encrypted PATs in a Worker KV namespace
- update config for `USER_PAT_STORE`
- document the new storage mechanism
- improve inline and module comments per `AGENTS.md`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877840658f08331b6c6e24e153b2e0c