### PR TITLE
Add files listing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,9 @@ before committing the file.
 Retrieves the raw text at the given `path` from the selected repository. The
 path is provided as a query parameter. When the file or repository is missing
 `content` will be `null` in the response.
+
+### `GET /api/files`
+
+Lists the files under a directory in the selected repository. Pass the
+`path` query parameter to specify the directory (or omit for the repo root).
+The response is an array like `{ files: string[] }` containing the entry names.


### PR DESCRIPTION
## Summary
- add `GET /api/files` endpoint to list directory entries
- document new endpoint in README

## Testing
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_68791342d8ac83319e7e97a770404445