### PR TITLE
Add jsonError helper for consistent error responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ High‑level overview of notable files. **Update this list whenever files are ad
 - `src/auth.ts` – OAuth flow, session lookup and PAT encryption helpers.
 - `src/repo.ts` – persistence of user repository preferences and repo creation.
 - `src/files.ts` – wrappers around the GitHub contents API.
+- `src/errors.ts` – helper for structured JSON error responses.
 - `tests/cookie.test.ts` – unit tests for `parseCookies` from `src/auth.ts`.
 - `tests/encryption.test.ts` – tests `encryptPAT` and `decryptPAT` helpers from `src/auth.ts`.
 - `tests/router.test.ts` – integration tests for the worker routes defined in `src/index.ts`.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Minimal response helper used by the router.
+ *
+ * The Cloudflare Worker returns many small error messages. To make
+ * them machine readable and language agnostic the frontend expects a
+ * standard `{ error: string }` envelope. Centralising the creation of
+ * these responses keeps each handler lean and ensures headers like
+ * `Content-Type` are applied uniformly.
+ */
+export function jsonError(code: number, key: string): Response {
+  const body = JSON.stringify({ error: key });
+  const headers = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
+  return new Response(body, { status: code, headers });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import {
 } from './auth';
 import { storeRepo, getRepo } from './repo';
 import { sanitizePath, commitFile, readFile, listFiles } from './files';
+import { jsonError } from './errors';
 
 /* -------------------------------------------------------------------------- */
 /* Utility to attach CORS headers to every response                           */
@@ -80,15 +81,15 @@ async function handleAuthCallback(request: Request, env: Env, url: URL): Promise
   const error = params.get('error');
   const cookies = parseCookies(request.headers.get('Cookie') || '');
 
-  if (error) return new Response(`GitHub error: ${error}`, { status: 400 });
+  if (error) return jsonError(400, 'GITHUB_ERROR');
   if (!code || !state || !cookies.oauth_state) {
-    return new Response('Missing OAuth values', { status: 400 });
+    return jsonError(400, 'MISSING_OAUTH');
   }
 
   const buf1 = new TextEncoder().encode(cookies.oauth_state);
   const buf2 = new TextEncoder().encode(state);
   if (!timingSafeEqual(buf1, buf2)) {
-    return new Response('Invalid OAuth state', { status: 400 });
+    return jsonError(400, 'INVALID_OAUTH_STATE');
   }
 
   try {
@@ -113,21 +114,21 @@ async function handleAuthCallback(request: Request, env: Env, url: URL): Promise
 
 async function handleStoreToken(request: Request, env: Env): Promise<Response> {
   const user = await getSessionUser(request, env);
-  if (!user) return new Response('Unauthorized', { status: 401 });
+  if (!user) return jsonError(401, 'UNAUTHORIZED');
 
   let body: { pat?: string };
   try {
     body = await request.json();
   } catch {
-    return new Response('Bad Request', { status: 400 });
+    return jsonError(400, 'BAD_REQUEST');
   }
 
   const pat = (body.pat || '').trim();
   if (pat.length === 0 || pat.length > 256) {
-    return new Response('Invalid token length', { status: 400 });
+    return jsonError(400, 'INVALID_TOKEN_LENGTH');
   }
   if (!/^((gh[pous]_|github_pat_)[A-Za-z0-9_]{20,}|[0-9a-f]{40})$/.test(pat)) {
-    return new Response('Malformed token', { status: 400 });
+    return jsonError(400, 'MALFORMED_TOKEN');
   }
 
   const verify = await fetch('https://api.github.com/user', {
@@ -138,9 +139,9 @@ async function handleStoreToken(request: Request, env: Env): Promise<Response> {
       'X-GitHub-Api-Version': '2022-11-28',
     },
   });
-  if (verify.status === 401) return new Response('Token not authorised', { status: 401 });
-  if (verify.status === 403) return new Response('GitHub rate limited; try later', { status: 429 });
-  if (!verify.ok) return new Response('GitHub check failed', { status: 502 });
+  if (verify.status === 401) return jsonError(401, 'TOKEN_UNAUTHORIZED');
+  if (verify.status === 403) return jsonError(429, 'RATE_LIMIT');
+  if (!verify.ok) return jsonError(502, 'GITHUB_CHECK_FAILED');
 
   await storeToken(user.id, pat, env);
   return new Response(null, { status: 204, headers: { 'Cache-Control': 'no-store' } });
@@ -158,18 +159,18 @@ async function handleLogout(request: Request, env: Env): Promise<Response> {
 
 async function handleSetRepo(request: Request, env: Env): Promise<Response> {
   const user = await getSessionUser(request, env);
-  if (!user) return new Response('Unauthorized', { status: 401 });
+  if (!user) return jsonError(401, 'UNAUTHORIZED');
 
   let body: any;
   try {
     body = await request.json();
   } catch {
-    return new Response('Bad Request', { status: 400 });
+    return jsonError(400, 'BAD_REQUEST');
   }
 
   const repo = (body?.repo || '').trim();
   if (!/^[\w.-]+\/[\w.-]+$/.test(repo)) {
-    return new Response('Invalid repository', { status: 400 });
+    return jsonError(400, 'INVALID_REPO');
   }
 
   await storeRepo(user.id, repo, env);
@@ -178,7 +179,7 @@ async function handleSetRepo(request: Request, env: Env): Promise<Response> {
 
 async function handleGetRepo(request: Request, env: Env): Promise<Response> {
   const user = await getSessionUser(request, env);
-  if (!user) return new Response('Unauthorized', { status: 401 });
+  if (!user) return jsonError(401, 'UNAUTHORIZED');
 
   const repo = await getRepo(user.id, env);
   return new Response(JSON.stringify({ repo }), {
@@ -188,26 +189,26 @@ async function handleGetRepo(request: Request, env: Env): Promise<Response> {
 
 async function handleCommitFile(request: Request, env: Env): Promise<Response> {
   const user = await getSessionUser(request, env);
-  if (!user) return new Response('Unauthorized', { status: 401 });
+  if (!user) return jsonError(401, 'UNAUTHORIZED');
 
   const [token, repo] = await Promise.all([
     getToken(user.id, env).catch(() => null),
     getRepo(user.id, env),
   ]);
-  if (!token || !repo) return new Response('No repository or token', { status: 400 });
+  if (!token || !repo) return jsonError(400, 'MISSING_REPO_OR_TOKEN');
 
   let body: any;
   try {
     body = await request.json();
   } catch {
-    return new Response('Bad Request', { status: 400 });
+    return jsonError(400, 'BAD_REQUEST');
   }
 
   const path = sanitizePath(body?.path);
   const content = body?.content;
   const message = (body?.message || `Add ${path}`).slice(0, 200);
   if (!path || typeof content !== 'string') {
-    return new Response('Invalid payload', { status: 400 });
+    return jsonError(400, 'INVALID_PAYLOAD');
   }
 
   try {
@@ -221,20 +222,20 @@ async function handleCommitFile(request: Request, env: Env): Promise<Response> {
 
 async function handleReadFile(request: Request, env: Env, url: URL): Promise<Response> {
   const user = await getSessionUser(request, env);
-  if (!user) return new Response('Unauthorized', { status: 401 });
+  if (!user) return jsonError(401, 'UNAUTHORIZED');
 
   const [token, repo] = await Promise.all([
     getToken(user.id, env).catch(() => null),
     getRepo(user.id, env),
   ]);
-  if (!token || !repo) return new Response('No repository or token', { status: 400 });
+  if (!token || !repo) return jsonError(400, 'MISSING_REPO_OR_TOKEN');
 
   const path = sanitizePath(url.searchParams.get('path'));
-  if (!path) return new Response('Invalid path', { status: 400 });
+  if (!path) return jsonError(400, 'INVALID_PATH');
 
   try {
     const text = await readFile(repo, path, token);
-    if (text === null) return new Response('Not Found', { status: 404 });
+    if (text === null) return jsonError(404, 'NOT_FOUND');
     return new Response(JSON.stringify({ content: text }), {
       headers: {
         'Content-Type': 'application/json',
@@ -248,17 +249,17 @@ async function handleReadFile(request: Request, env: Env, url: URL): Promise<Res
 
 async function handleListFiles(request: Request, env: Env, url: URL): Promise<Response> {
   const user = await getSessionUser(request, env);
-  if (!user) return new Response('Unauthorized', { status: 401 });
+  if (!user) return jsonError(401, 'UNAUTHORIZED');
 
   const [token, repo] = await Promise.all([
     getToken(user.id, env).catch(() => null),
     getRepo(user.id, env),
   ]);
-  if (!token || !repo) return new Response('No repository or token', { status: 400 });
+  if (!token || !repo) return jsonError(400, 'MISSING_REPO_OR_TOKEN');
 
   const rawDir = (url.searchParams.get('path') || '').trim();
   const dir = rawDir === '' ? '' : sanitizePath(rawDir);
-  if (dir === null) return new Response('Invalid path', { status: 400 });
+  if (dir === null) return jsonError(400, 'INVALID_PATH');
 
   try {
     const entries = await listFiles(repo, dir, token);
@@ -323,6 +324,6 @@ export default {
     }
 
     if (res) return withCors(request, res);
-    return withCors(request, new Response('Not Found', { status: 404 }));
+    return withCors(request, jsonError(404, 'NOT_FOUND'));
   },
 };


### PR DESCRIPTION
## Summary
- introduce `jsonError` to generate consistent JSON error envelopes
- use `jsonError` in all handlers for non-500 errors
- document new helper in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a7fb407b08331b67eebc81b295150