### PR TITLE
Fix token deletion routing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -460,6 +460,10 @@ export default {
       res = await handleAuthCallback(request, env, url);
     } else if (pathname === '/api/token' && method === 'POST') {
       res = await handleStoreToken(request, env);
+    } else if (pathname === '/api/token' && method === 'DELETE') {
+      // Remove the user's saved personal access token so any repository
+      // operations fail until a new token is provided.
+      res = await handleDeleteToken(request, env);
     } else if (pathname === '/api/logout' && method === 'POST') {
       res = await handleLogout(request, env);
     } else if (pathname === '/api/repository' && method === 'POST') {


### PR DESCRIPTION
## Summary
- handle DELETE /api/token in router

## Testing
- `npx vitest run --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687b9580e5988331a6df8b2f9081efb2